### PR TITLE
Fix "Artboard name is url encoded which breaks preview when using / in the name"

### DIFF
--- a/src/create-preview.js
+++ b/src/create-preview.js
@@ -14,7 +14,8 @@ export default (artboard
 , options) => {
   // export file
   sketch.export(artboard.object, options)
-  let file = options.output + "/" + artboard.name + "@" + options.scales + "x." + options.formats
+  let artboardFileName =  artboard.name.replace(/%2F/gi, '/').replace(/%252F/gi, '/')
+  let file = options.output + "/" + artboardFileName + "@" + options.scales + "x." + options.formats
   let htmlFile = `${options.output}/${artboard.name}.html`
   let align = artboard.name.split(':').pop().trim()
 

--- a/src/create-preview.js
+++ b/src/create-preview.js
@@ -45,7 +45,7 @@ export default (artboard
     </head>
     <body>
       <div class="flex">
-        <img src="${file}" alt="${artboard.name}" /
+        <img src="${file}" alt="${artboard.name}" />
       </div>
     </body>
   </html>`


### PR DESCRIPTION
Tried to make a fix for the issue in https://github.com/lukasoppermann/browser-preview/issues/25. Not sure if this is the right approach, I had the same issue and for me the slash was encoded as %252F rather than %2F so I took both cases.